### PR TITLE
introducing pluggable reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,40 @@ The arguments are:
 - **refresh** how often should the app refresh and store a point in the DB
 - **retain** how long should points be kept in the DB
 - **dbName** where to store the history (default 'offsetapp')
+- **pluginsArgs** additional arguments used by extensions (see below)
 
+Writing and using plugins
+============================
+
+Kafka Offset Monitor allows you to plug-in additional offset info reporters in case you want this information to be logged or stored somewhere. In order to write your own plugin,
+all you need to do is to implement OffsetInfoReporter trait:
+
+```
+trait OffsetInfoReporter {
+  def report(info: IndexedSeq[OffsetInfo])
+  def cleanupOldData() = {}
+}
+```
+
+It is also required, that implementation has a constructor with String as the only parameter, and this parameter will be set to pluginsArgs argument value.
+Its up to you how you want to utilize this argument and configure your plugin.
+
+When building a plugin you may find it difficult to set up dependency to Kafka Offset Monitor classes, as currently artifacts are not published to public repos.
+As long as this is true you will need to use local maven repo and just publish Kafka Offset Monitor artifact with: ```sbt publishM2```
+
+Assuming you have a custom implementation of OffsetInfoReporter in a jar file, running it is as simple as adding the jar to the classpath when running app:
+
+```
+java -cp KafkaOffsetMonitor-assembly-0.3.0.jar:kafka-offset-monitor-another-db-reporter.jar \
+     com.quantifind.kafka.offsetapp.OffsetGetterWeb \
+     --zk zk-server1,zk-server2 \
+     --port 8080 \
+     --refresh 10.seconds \
+     --retain 2.days
+     --pluginsArgs anotherDbHost=host1,anotherDbPort=555
+```
+
+For complete working example you can check [kafka-offset-monitor-graphite](https://github.com/allegro/kafka-offset-monitor-graphite), a plugin reporting offset information to Graphite.
 
 Contributing
 ============

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -44,7 +44,8 @@ object KafkaUtilsBuild extends Build {
       "com.quantifind" %% "sumac" % "0.3.0",
       "com.typesafe.slick" %% "slick" % "2.0.0",
       "org.xerial" % "sqlite-jdbc" % "3.7.2",
-      "com.twitter" % "util-core" % "3.0.0"),
+      "com.twitter" % "util-core" % "3.0.0",
+      "org.reflections" % "reflections" % "0.9.10"),
     resolvers ++= Seq(
       "java m2" at "http://download.java.net/maven/2",
       "twitter repo" at "http://maven.twttr.com"))

--- a/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterApp.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterApp.scala
@@ -2,8 +2,6 @@ package com.quantifind.kafka.offsetapp
 
 import java.text.NumberFormat
 
-import com.quantifind.kafka.OffsetGetter.OffsetInfo
-
 import scala.concurrent.duration._
 
 import com.quantifind.sumac.{ ArgMain, FieldArgs }

--- a/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterWeb.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterWeb.scala
@@ -1,9 +1,14 @@
 package com.quantifind.kafka.offsetapp
 
+import java.lang.reflect.Constructor
+import java.util
 import java.util.{Timer, TimerTask}
 
+import com.quantifind.kafka.offsetapp.sqlite.SQLiteOffsetInfoReporter
 import com.quantifind.utils.Utils.retry
+import org.reflections.Reflections
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 import com.quantifind.kafka.OffsetGetter.KafkaInfo
@@ -33,6 +38,8 @@ class OWArgs extends OffsetGetterArgs with UnfilteredWebApp.Arguments {
   var dbName: String = "offsetapp"
 
   lazy val db = new OffsetDB(dbName)
+
+  var pluginsArgs : String = _
 }
 
 /**
@@ -41,41 +48,45 @@ class OWArgs extends OffsetGetterArgs with UnfilteredWebApp.Arguments {
  * Date: 1/23/14
  */
 object OffsetGetterWeb extends UnfilteredWebApp[OWArgs] with Logging {
+
   def htmlRoot: String = "/offsetapp"
 
   val timer = new Timer()
   var zkClient: ZkClient = null
+  var reporters: mutable.Set[OffsetInfoReporter] = null
 
-  def writeToDb(args: OWArgs) {
+  def retryTask[T](fn: => T) {
+    try {
+      retry(3) {
+        fn
+      }
+    } catch {
+      case NonFatal(e) =>
+        error("Failed to run scheduled task", e)
+    }
+  }
+
+  def reportOffsets(args: OWArgs) {
     val groups = getGroups(args)
     groups.foreach {
       g =>
         val inf = getInfo(g, args).offsets.toIndexedSeq
-        info(s"inserting ${inf.size}")
-        args.db.insertAll(inf)
+        info(s"reporting ${inf.size}")
+        reporters.foreach( reporter => retryTask { reporter.report(inf) } )
     }
   }
 
   def schedule(args: OWArgs) {
-    def retryTask[T](fn: => T) {
-      try {
-        retry(3) {
-          fn
-        }
-      } catch {
-        case NonFatal(e) =>
-          error("Failed to run scheduled task", e)
-      }
-    }
 
     timer.scheduleAtFixedRate(new TimerTask() {
       override def run() {
-        retryTask(writeToDb(args))
+        reportOffsets(args)
       }
     }, 0, args.refresh.toMillis)
+
     timer.scheduleAtFixedRate(new TimerTask() {
       override def run() {
-        retryTask(args.db.emptyOld(System.currentTimeMillis - args.retain.toMillis))
+        reporters.foreach(reporter => retryTask({reporter.cleanupOldData()}))
       }
     }, args.retain.toMillis, args.retain.toMillis)
   }
@@ -141,6 +152,9 @@ object OffsetGetterWeb extends UnfilteredWebApp[OWArgs] with Logging {
     zkClient = new ZkClient(args.zk,  args.zkSessionTimeout.toMillis.toInt,
                                       args.zkConnectionTimeout.toMillis.toInt,
                                       ZKStringSerializer)
+
+    reporters = createOffsetInfoReporters(args)
+
     schedule(args)
 
     def intent: Plan.Intent = {
@@ -163,5 +177,25 @@ object OffsetGetterWeb extends UnfilteredWebApp[OWArgs] with Logging {
       case GET(Path(Seg("activetopics" :: Nil))) =>
         JsonContent ~> ResponseString(write(getActiveTopics(args)))
     }
+  }
+
+  def createOffsetInfoReporters(args: OWArgs) = {
+
+    val reflections = new Reflections()
+
+    val reportersTypes: util.Set[Class[_ <: OffsetInfoReporter]] = reflections.getSubTypesOf(classOf[OffsetInfoReporter])
+
+    val reportersSet: mutable.Set[Class[_ <: OffsetInfoReporter]] = scala.collection.JavaConversions.asScalaSet(reportersTypes)
+
+    // SQLiteOffsetInfoReporter as a main storage is instantiated explicitly outside this loop so it is filtered out
+    reportersSet
+      .filter(!_.equals(classOf[SQLiteOffsetInfoReporter]))
+      .map((reporterType: Class[_ <: OffsetInfoReporter]) =>  createReporterInstance(reporterType, args.pluginsArgs))
+      .+(new SQLiteOffsetInfoReporter(argHolder.db, args))
+  }
+
+  def createReporterInstance(reporterClass: Class[_ <: OffsetInfoReporter], rawArgs: String): OffsetInfoReporter = {
+    val constructor: Constructor[_ <: OffsetInfoReporter] = reporterClass.getConstructor(classOf[String])
+    constructor.newInstance(rawArgs)
   }
 }

--- a/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterWeb.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/OffsetGetterWeb.scala
@@ -1,7 +1,6 @@
 package com.quantifind.kafka.offsetapp
 
 import java.lang.reflect.Constructor
-import java.util
 import java.util.{Timer, TimerTask}
 
 import com.quantifind.kafka.offsetapp.sqlite.SQLiteOffsetInfoReporter
@@ -183,7 +182,7 @@ object OffsetGetterWeb extends UnfilteredWebApp[OWArgs] with Logging {
 
     val reflections = new Reflections()
 
-    val reportersTypes: util.Set[Class[_ <: OffsetInfoReporter]] = reflections.getSubTypesOf(classOf[OffsetInfoReporter])
+    val reportersTypes: java.util.Set[Class[_ <: OffsetInfoReporter]] = reflections.getSubTypesOf(classOf[OffsetInfoReporter])
 
     val reportersSet: mutable.Set[Class[_ <: OffsetInfoReporter]] = scala.collection.JavaConversions.asScalaSet(reportersTypes)
 

--- a/src/main/scala/com/quantifind/kafka/offsetapp/OffsetInfoReporter.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/OffsetInfoReporter.scala
@@ -1,0 +1,8 @@
+package com.quantifind.kafka.offsetapp
+
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+
+trait OffsetInfoReporter {
+  def report(info: IndexedSeq[OffsetInfo])
+  def cleanupOldData() = {}
+}

--- a/src/main/scala/com/quantifind/kafka/offsetapp/sqlite/SqliteOffsetInfoReporter.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/sqlite/SqliteOffsetInfoReporter.scala
@@ -1,0 +1,16 @@
+package com.quantifind.kafka.offsetapp.sqlite
+
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+import com.quantifind.kafka.offsetapp.{OWArgs, OffsetDB, OffsetInfoReporter}
+
+class SQLiteOffsetInfoReporter(db: OffsetDB, args: OWArgs) extends OffsetInfoReporter {
+
+  override def report(info: IndexedSeq[OffsetInfo]): Unit = {
+    db.insertAll(info)
+  }
+
+  override def cleanupOldData() {
+    db.emptyOld(System.currentTimeMillis - args.retain.toMillis)
+  }
+
+}


### PR DESCRIPTION
Proposal of the solution for issue #53.

The idea is that we introduce a simple abstraction for reporting offset info (OffsetInfoReporter trait) without changing anything in the actual behavior. 
 
In case some additional implementations of OffsetInfoReporter are found, the app will instantiate them and use the same way as default sqllite reporter. Passing arguments was a bit tricky and I choose to keep it simple. (All arguments for all plugins are passed in one additional argument : pluginsArgs)

We have also an example plugin using this solution and reporting offset info to graphite: https://github.com/rzukow/kafka-offset-monitor-graphite-reporter

What do you think? Is it possible to introduce something similar so we could plug in our graphite support?