### PR TITLE
Added support for new offset storage formats: kafka, storm

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,8 +20,9 @@ object KafkaUtilsBuild extends Build {
       "JBoss Repository" at "http://repository.jboss.org/nexus/content/repositories/releases/"),
     libraryDependencies ++= Seq(
       "log4j" % "log4j" % "1.2.17",
-      "org.scalatest" %% "scalatest" % "1.9.1" % "test",
-      "org.apache.kafka" %% "kafka" % "0.8.1"))
+      "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+      "org.mockito" % "mockito-all" % "1.10.19" % "test",
+      "org.apache.kafka" %% "kafka" % "0.8.2.1"))
 
   val slf4jVersion = "1.6.1"
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.reflections.Reflections=ERROR

--- a/src/main/scala/com/quantifind/kafka/OffsetGetter.scala
+++ b/src/main/scala/com/quantifind/kafka/OffsetGetter.scala
@@ -1,23 +1,19 @@
 package com.quantifind.kafka
 
-import scala.collection._
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
 
 import com.quantifind.kafka.OffsetGetter.{BrokerInfo, KafkaInfo, OffsetInfo}
-import kafka.api.{OffsetRequest, PartitionOffsetRequestInfo}
-import kafka.common.{BrokerNotAvailableException, TopicAndPartition}
-import kafka.consumer.SimpleConsumer
-import kafka.utils.{Json, Logging, ZkUtils}
-import org.I0Itec.zkclient.ZkClient
-import org.I0Itec.zkclient.exception.ZkNoNodeException
+import com.quantifind.kafka.core.{KafkaOffsetGetter, StormOffsetGetter, ZKOffsetGetter}
+import com.quantifind.kafka.offsetapp.OffsetGetterArgs
 import com.twitter.util.Time
-import org.apache.zookeeper.data.Stat
-import scala.util.control.NonFatal
+import kafka.common.BrokerNotAvailableException
+import kafka.consumer.{Consumer, ConsumerConfig, ConsumerConnector, SimpleConsumer}
+import kafka.utils.{Json, Logging, ZKStringSerializer, ZkUtils}
+import org.I0Itec.zkclient.ZkClient
 
-/**
- * a nicer version of kafka's ConsumerOffsetChecker tool
- * User: pierre
- * Date: 1/22/14
- */
+import scala.collection._
+import scala.util.control.NonFatal
 
 case class Node(name: String, children: Seq[Node] = Seq())
 
@@ -29,11 +25,20 @@ case class TopicAndConsumersDetailsWrapper(consumers: TopicAndConsumersDetails)
 
 case class ConsumerDetail(name: String)
 
-class OffsetGetter(zkClient: ZkClient) extends Logging {
+trait OffsetGetter  extends Logging {
 
-  private val consumerMap: mutable.Map[Int, Option[SimpleConsumer]] = mutable.Map()
+  val consumerMap: mutable.Map[Int, Option[SimpleConsumer]] = mutable.Map()
+  def zkClient: ZkClient
 
-  private def getConsumer(bid: Int): Option[SimpleConsumer] = {
+  //  kind of interface methods
+  def getTopicList(group: String): List[String]
+  def getGroups: Seq[String]
+  def getTopicMap: Map[String, Seq[String]]
+  def getActiveTopicMap: Map[String, Seq[String]]
+  def processPartition(group: String, topic: String, pid: Int): Option[OffsetInfo]
+
+  // get the Kafka simple consumer so that we can fetch broker offsets
+  protected def getConsumer(bid: Int): Option[SimpleConsumer] = {
     try {
       ZkUtils.readDataMaybeNull(zkClient, ZkUtils.BrokerIdsPath + "/" + bid) match {
         case (Some(brokerInfoString), _) =>
@@ -56,42 +61,7 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
     }
   }
 
-  private def processPartition(group: String, topic: String, pid: Int): Option[OffsetInfo] = {
-    try {
-      val (offset, stat: Stat) = ZkUtils.readData(zkClient, s"${ZkUtils.ConsumersPath}/$group/offsets/$topic/$pid")
-      val (owner, _) = ZkUtils.readDataMaybeNull(zkClient, s"${ZkUtils.ConsumersPath}/$group/owners/$topic/$pid")
-
-      ZkUtils.getLeaderForPartition(zkClient, topic, pid) match {
-        case Some(bid) =>
-          val consumerOpt = consumerMap.getOrElseUpdate(bid, getConsumer(bid))
-          consumerOpt map {
-            consumer =>
-              val topicAndPartition = TopicAndPartition(topic, pid)
-              val request =
-                OffsetRequest(immutable.Map(topicAndPartition -> PartitionOffsetRequestInfo(OffsetRequest.LatestTime, 1)))
-              val logSize = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets.head
-
-              OffsetInfo(group = group,
-                topic = topic,
-                partition = pid,
-                offset = offset.toLong,
-                logSize = logSize,
-                owner = owner,
-                creation = Time.fromMilliseconds(stat.getCtime),
-                modified = Time.fromMilliseconds(stat.getMtime))
-          }
-        case None =>
-          error("No broker for partition %s - %s".format(topic, pid))
-          None
-      }
-    } catch {
-      case NonFatal(t) =>
-        error(s"Could not parse partition info. group: [$group] topic: [$topic]", t)
-        None
-    }
-  }
-
-  private def processTopic(group: String, topic: String): Seq[OffsetInfo] = {
+  protected def processTopic(group: String, topic: String): Seq[OffsetInfo] = {
     val pidMap = ZkUtils.getPartitionsForTopics(zkClient, Seq(topic))
     for {
       partitions <- pidMap.get(topic).toSeq
@@ -100,14 +70,15 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
     } yield info
   }
 
-  private def brokerInfo(): Iterable[BrokerInfo] = {
+  protected def brokerInfo(): Iterable[BrokerInfo] = {
     for {
       (bid, consumerOpt) <- consumerMap
       consumer <- consumerOpt
     } yield BrokerInfo(id = bid, host = consumer.host, port = consumer.port)
   }
 
-  private def offsetInfo(group: String, topics: Seq[String] = Seq()): Seq[OffsetInfo] = {
+  protected def offsetInfo(group: String, topics: Seq[String] = Seq()): Seq[OffsetInfo] = {
+
     val topicList = if (topics.isEmpty) {
       getTopicList(group)
     } else {
@@ -117,14 +88,8 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
     topicList.sorted.flatMap(processTopic(group, _))
   }
 
-  def getTopicList(group: String): List[String] = {
-    try {
-      ZkUtils.getChildren(zkClient, s"${ZkUtils.ConsumersPath}/$group/offsets").toList
-    } catch {
-      case _: ZkNoNodeException => List()
-    }
-  }
 
+  // get information about a consumer group and the topics it consumes
   def getInfo(group: String, topics: Seq[String] = Seq()): KafkaInfo = {
     val off = offsetInfo(group, topics)
     val brok = brokerInfo()
@@ -135,14 +100,23 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
     )
   }
 
-  def getGroups: Seq[String] = {
+  // get list of all topics
+  def getTopics: Seq[String] = {
     try {
-      ZkUtils.getChildren(zkClient, ZkUtils.ConsumersPath)
+      ZkUtils.getChildren(zkClient, ZkUtils.BrokerTopicsPath).sortWith(_ < _)
     } catch {
       case NonFatal(t) =>
-        error(s"could not get groups because of ${t.getMessage}", t)
+        error(s"could not get topics because of ${t.getMessage}", t)
         Seq()
+
     }
+  }
+
+  def getClusterViz: Node = {
+    val clusterNodes = ZkUtils.getAllBrokersInCluster(zkClient).map((broker) => {
+      Node(broker.connectionString, Seq())
+    })
+    Node("KafkaCluster", clusterNodes)
   }
 
   /**
@@ -191,63 +165,6 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
   def mapConsumersToKafkaInfo(consumers: Seq[String], topic: String): Seq[KafkaInfo] =
     consumers.map(getInfo(_, Seq(topic)))
 
-  def getTopics: Seq[String] = {
-    try {
-      ZkUtils.getChildren(zkClient, ZkUtils.BrokerTopicsPath).sortWith(_ < _)
-    } catch {
-      case NonFatal(t) =>
-        error(s"could not get topics because of ${t.getMessage}", t)
-        Seq()
-
-    }
-  }
-
-
-  /**
-   * Returns a map of active topics -> list of consumers from zookeeper, ones that have IDS attached to them
-   */
-  def getActiveTopicMap: Map[String, Seq[String]] = {
-    try {
-      ZkUtils.getChildren(zkClient, ZkUtils.ConsumersPath).flatMap {
-        group =>
-          try {
-            ZkUtils.getConsumersPerTopic(zkClient, group).keySet.map {
-              key =>
-                key -> group
-            }
-          } catch {
-            case NonFatal(t) =>
-              error(s"could not get consumers for group $group", t)
-              Seq()
-          }
-      }.groupBy(_._1).mapValues {
-        _.unzip._2
-      }
-    } catch {
-      case NonFatal(t) =>
-        error(s"could not get topic maps because of ${t.getMessage}", t)
-        Map()
-    }
-  }
-
-  /**
-   * Returns a map of topics -> list of consumers, including non-active
-   */
-  def getTopicMap: Map[String, Seq[String]] = {
-    try {
-      ZkUtils.getChildren(zkClient, ZkUtils.ConsumersPath).flatMap {
-        group => {
-          getTopicList(group).map(topic => topic -> group)
-        }
-      }.groupBy(_._1).mapValues {
-        _.unzip._2
-      }
-    } catch {
-      case NonFatal(t) =>
-        error(s"could not get topic maps because of ${t.getMessage}", t)
-        Map()
-    }
-  }
 
   def getActiveTopics: Node = {
     val topicMap = getActiveTopicMap
@@ -260,13 +177,6 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
     }.toSeq)
   }
 
-  def getClusterViz: Node = {
-    val clusterNodes = ZkUtils.getAllBrokersInCluster(zkClient).map((broker) => {
-      Node(broker.getConnectionString(), Seq())
-    })
-    Node("KafkaCluster", clusterNodes)
-  }
-
   def close() {
     for (consumerOpt <- consumerMap.values) {
       consumerOpt match {
@@ -275,7 +185,6 @@ class OffsetGetter(zkClient: ZkClient) extends Logging {
       }
     }
   }
-
 }
 
 object OffsetGetter {
@@ -295,4 +204,48 @@ object OffsetGetter {
     val lag = logSize - offset
   }
 
+  val kafkaOffsetListenerStarted: AtomicBoolean = new AtomicBoolean(false)
+  var zkClient: ZkClient = null
+  var consumerConnector: ConsumerConnector = null
+
+  def createZKClient(args: OffsetGetterArgs): ZkClient = {
+    new ZkClient(args.zk,
+      args.zkSessionTimeout.toMillis.toInt,
+      args.zkConnectionTimeout.toMillis.toInt,
+      ZKStringSerializer)
+  }
+
+  def createKafkaConsumerConnector(args: OffsetGetterArgs): ConsumerConnector = {
+    val props: Properties = new Properties()
+    // we want to be unique
+    props.put("group.id", "KafkaOffsetMonitor-" + System.currentTimeMillis)
+    props.put("zookeeper.connect", args.zk)
+    // must enable it
+    props.put("exclude.internal.topics", "false")
+    // we don't want to commit any thing, will always start from latest
+    props.put("auto.commit.enable", "false")
+    props.put("auto.offset.reset", if (args.kafkaOffsetForceFromStart) "smallest" else "largest")
+
+    Consumer.create(new ConsumerConfig(props))
+  }
+
+  def getInstance(args: OffsetGetterArgs): OffsetGetter = {
+
+    if (kafkaOffsetListenerStarted.compareAndSet(false, true)) {
+      zkClient = createZKClient(args)
+      if (args.offsetStorage.toLowerCase == "kafka") {
+        consumerConnector = createKafkaConsumerConnector(args)
+        KafkaOffsetGetter.startOffsetListener(consumerConnector)
+      }
+    }
+
+    args.offsetStorage.toLowerCase match {
+      case "kafka" =>
+        new KafkaOffsetGetter(zkClient)
+      case "storm" =>
+        new StormOffsetGetter(zkClient, args.stormZKOffsetBase)
+      case _ =>
+        new ZKOffsetGetter(zkClient)
+    }
+  }
 }

--- a/src/main/scala/com/quantifind/kafka/core/KafkaOffsetGetter.scala
+++ b/src/main/scala/com/quantifind/kafka/core/KafkaOffsetGetter.scala
@@ -1,0 +1,240 @@
+package com.quantifind.kafka.core
+
+import java.nio.ByteBuffer
+
+import com.quantifind.kafka.OffsetGetter
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+import com.quantifind.utils.ZkUtilsWrapper
+import com.twitter.util.Time
+import kafka.api.{OffsetRequest, PartitionOffsetRequestInfo}
+import kafka.common.{OffsetAndMetadata, TopicAndPartition}
+import kafka.consumer.{ConsumerConnector, KafkaStream}
+import kafka.message.MessageAndMetadata
+import kafka.utils.{Logging}
+import org.I0Itec.zkclient.ZkClient
+
+import scala.collection._
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.control.NonFatal
+
+class KafkaOffsetGetter(theZkClient: ZkClient, zkUtils: ZkUtilsWrapper = new ZkUtilsWrapper) extends OffsetGetter {
+  import KafkaOffsetGetter._
+
+  override val zkClient = theZkClient
+
+  override def processPartition(group: String, topic: String, pid: Int): Option[OffsetInfo] = {
+    try {
+      zkUtils.getLeaderForPartition(zkClient, topic, pid) match {
+        case Some(bid) =>
+          val consumerOpt = consumerMap.getOrElseUpdate(bid, getConsumer(bid))
+          consumerOpt flatMap { consumer =>
+              val topicAndPartition = TopicAndPartition(topic, pid)
+              offsetMap.get(GroupTopicPartition(group, topicAndPartition)) map { offsetMetaData =>
+
+                val request =
+                  OffsetRequest(immutable.Map(topicAndPartition -> PartitionOffsetRequestInfo(OffsetRequest.LatestTime, 1)))
+                val logSize = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets.head
+
+                OffsetInfo(group = group,
+                  topic = topic,
+                  partition = pid,
+                  offset = offsetMetaData.offset,
+                  logSize = logSize,
+                  owner = Some("NA"),
+                  creation = Time.fromMilliseconds(offsetMetaData.timestamp),
+                  modified = Time.fromMilliseconds(offsetMetaData.timestamp))
+              }
+          }
+        case None =>
+          error("No broker for partition %s - %s".format(topic, pid))
+          None
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"Could not parse partition info. group: [$group] topic: [$topic]", t)
+        None
+    }
+  }
+
+  override def getGroups: Seq[String] = {
+    topicAndGroups.groupBy(_.group).keySet.toSeq
+  }
+
+  override def getTopicList(group: String): List[String] = {
+    topicAndGroups.filter(_.group == group).groupBy(_.topic).keySet.toList
+  }
+
+  override def getTopicMap: Map[String, scala.Seq[String]] = {
+    topicAndGroups.groupBy(_.topic).mapValues(_.map(_.group).toSeq)
+  }
+
+  override def getActiveTopicMap: Map[String, Seq[String]] = {
+    getTopicMap
+  }
+}
+
+object KafkaOffsetGetter extends Logging {
+
+  val ConsumerOffsetTopic = "__consumer_offsets"
+
+  val offsetMap: mutable.Map[GroupTopicPartition, OffsetAndMetadata] = mutable.HashMap()
+  val topicAndGroups: mutable.Set[TopicAndGroup] = mutable.HashSet()
+
+  def startOffsetListener(consumerConnector: ConsumerConnector) = {
+
+    Future {
+      try {
+        logger.info("Staring Kafka offset topic listener")
+        val offsetMsgStream: KafkaStream[Array[Byte], Array[Byte]] = consumerConnector
+          .createMessageStreams(Map(ConsumerOffsetTopic -> 1))
+          .get(ConsumerOffsetTopic).map(_.head) match {
+          case Some(s) => s
+          case None => throw new IllegalStateException("Cannot create a consumer stream on offset topic ")
+        }
+
+        val it = offsetMsgStream.iterator()
+        while (true) {
+          try {
+            val offsetMsg: MessageAndMetadata[Array[Byte], Array[Byte]] = it.next()
+            val commitKey: GroupTopicPartition = readMessageKey(ByteBuffer.wrap(offsetMsg.key()))
+            val commitValue: OffsetAndMetadata = readMessageValue(ByteBuffer.wrap(offsetMsg.message()))
+            info("Processed commit message: " + commitKey + " => " + commitValue)
+            offsetMap += (commitKey -> commitValue)
+            topicAndGroups += TopicAndGroup(commitKey.topicPartition.topic, commitKey.group)
+          } catch {
+            case e: RuntimeException =>
+              // sometimes offsetMsg.key() || offsetMsg.message() throws NPE
+              warn("Failed to process one of the commit message due to exception. The 'bad' message will be skipped", e)
+          }
+        }
+      } catch {
+        case e: Throwable =>
+          fatal("Offset topic listener aborted dur to unexpected exception", e)
+          System.exit(1)
+      }
+    }
+  }
+
+  // massive code stealing from kafka.server.OffsetManager
+
+  import java.nio.ByteBuffer
+
+  import org.apache.kafka.common.protocol.types.Type.{INT32, INT64, STRING}
+  import org.apache.kafka.common.protocol.types.{Field, Schema, Struct}
+
+
+  private case class KeyAndValueSchemas(keySchema: Schema, valueSchema: Schema)
+
+  private val OFFSET_COMMIT_KEY_SCHEMA_V0 = new Schema(new Field("group", STRING),
+                                                       new Field("topic", STRING),
+                                                       new Field("partition", INT32))
+  private val KEY_GROUP_FIELD = OFFSET_COMMIT_KEY_SCHEMA_V0.get("group")
+  private val KEY_TOPIC_FIELD = OFFSET_COMMIT_KEY_SCHEMA_V0.get("topic")
+  private val KEY_PARTITION_FIELD = OFFSET_COMMIT_KEY_SCHEMA_V0.get("partition")
+
+  private val OFFSET_COMMIT_VALUE_SCHEMA_V0 = new Schema(new Field("offset", INT64),
+                                                         new Field("metadata", STRING, "Associated metadata.", ""),
+                                                         new Field("timestamp", INT64))
+
+  private val OFFSET_COMMIT_VALUE_SCHEMA_V1 = new Schema(new Field("offset", INT64),
+                                                         new Field("metadata", STRING, "Associated metadata.", ""),
+                                                         new Field("commit_timestamp", INT64),
+                                                         new Field("expire_timestamp", INT64))
+
+  private val VALUE_OFFSET_FIELD_V0 = OFFSET_COMMIT_VALUE_SCHEMA_V0.get("offset")
+  private val VALUE_METADATA_FIELD_V0 = OFFSET_COMMIT_VALUE_SCHEMA_V0.get("metadata")
+  private val VALUE_TIMESTAMP_FIELD_V0 = OFFSET_COMMIT_VALUE_SCHEMA_V0.get("timestamp")
+
+  private val VALUE_OFFSET_FIELD_V1 = OFFSET_COMMIT_VALUE_SCHEMA_V1.get("offset")
+  private val VALUE_METADATA_FIELD_V1 = OFFSET_COMMIT_VALUE_SCHEMA_V1.get("metadata")
+  private val VALUE_COMMIT_TIMESTAMP_FIELD_V1 = OFFSET_COMMIT_VALUE_SCHEMA_V1.get("commit_timestamp")
+  // private val VALUE_EXPIRE_TIMESTAMP_FIELD_V1 = OFFSET_COMMIT_VALUE_SCHEMA_V1.get("expire_timestamp")
+
+  // map of versions to schemas
+  private val OFFSET_SCHEMAS = Map(0 -> KeyAndValueSchemas(OFFSET_COMMIT_KEY_SCHEMA_V0, OFFSET_COMMIT_VALUE_SCHEMA_V0),
+                                   1 -> KeyAndValueSchemas(OFFSET_COMMIT_KEY_SCHEMA_V0, OFFSET_COMMIT_VALUE_SCHEMA_V1))
+
+  private def schemaFor(version: Int) = {
+    val schemaOpt = OFFSET_SCHEMAS.get(version)
+    schemaOpt match {
+      case Some(schema) => schema
+      case _ => throw new RuntimeException("Unknown offset schema version " + version)
+    }
+  }
+
+  case class MessageValueStructAndVersion(value: Struct, version: Short)
+
+  case class TopicAndGroup(topic: String, group: String)
+
+  case class GroupTopicPartition(group: String, topicPartition: TopicAndPartition) {
+
+    def this(group: String, topic: String, partition: Int) =
+      this(group, new TopicAndPartition(topic, partition))
+
+    override def toString =
+      "[%s,%s,%d]".format(group, topicPartition.topic, topicPartition.partition)
+  }
+
+  /**
+   * Decodes the offset messages' key
+   *
+   * @param buffer input byte-buffer
+   * @return an GroupTopicPartition object
+   */
+  private def readMessageKey(buffer: ByteBuffer): GroupTopicPartition = {
+    val version = buffer.getShort()
+    val keySchema = schemaFor(version).keySchema
+    val key = keySchema.read(buffer).asInstanceOf[Struct]
+
+    val group = key.get(KEY_GROUP_FIELD).asInstanceOf[String]
+    val topic = key.get(KEY_TOPIC_FIELD).asInstanceOf[String]
+    val partition = key.get(KEY_PARTITION_FIELD).asInstanceOf[Int]
+
+    GroupTopicPartition(group, TopicAndPartition(topic, partition))
+  }
+
+  /**
+   * Decodes the offset messages' payload and retrieves offset and metadata from it
+   *
+   * @param buffer input byte-buffer
+   * @return an offset-metadata object from the message
+   */
+  private def readMessageValue(buffer: ByteBuffer): OffsetAndMetadata = {
+    val structAndVersion = readMessageValueStruct(buffer)
+
+    if (structAndVersion.value == null) { // tombstone
+      null
+    } else {
+      if (structAndVersion.version == 0) {
+        val offset = structAndVersion.value.get(VALUE_OFFSET_FIELD_V0).asInstanceOf[Long]
+        val metadata = structAndVersion.value.get(VALUE_METADATA_FIELD_V0).asInstanceOf[String]
+        val timestamp = structAndVersion.value.get(VALUE_TIMESTAMP_FIELD_V0).asInstanceOf[Long]
+
+        OffsetAndMetadata(offset, metadata, timestamp)
+      } else if (structAndVersion.version == 1) {
+        val offset = structAndVersion.value.get(VALUE_OFFSET_FIELD_V1).asInstanceOf[Long]
+        val metadata = structAndVersion.value.get(VALUE_METADATA_FIELD_V1).asInstanceOf[String]
+        val commitTimestamp = structAndVersion.value.get(VALUE_COMMIT_TIMESTAMP_FIELD_V1).asInstanceOf[Long]
+        // not supported in 0.8.2
+        // val expireTimestamp = structAndVersion.value.get(VALUE_EXPIRE_TIMESTAMP_FIELD_V1).asInstanceOf[Long]
+
+        OffsetAndMetadata(offset, metadata, commitTimestamp)
+      } else {
+        throw new IllegalStateException("Unknown offset message version: " + structAndVersion.version)
+      }
+    }
+  }
+
+  private def readMessageValueStruct(buffer: ByteBuffer): MessageValueStructAndVersion = {
+    if(buffer == null) { // tombstone
+      MessageValueStructAndVersion(null, -1)
+    } else {
+      val version = buffer.getShort()
+      val valueSchema = schemaFor(version).valueSchema
+      val value = valueSchema.read(buffer).asInstanceOf[Struct]
+
+      MessageValueStructAndVersion(value, version)
+    }
+  }
+}

--- a/src/main/scala/com/quantifind/kafka/core/StormOffsetGetter.scala
+++ b/src/main/scala/com/quantifind/kafka/core/StormOffsetGetter.scala
@@ -1,0 +1,119 @@
+package com.quantifind.kafka.core
+
+import com.quantifind.kafka.OffsetGetter
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+import com.quantifind.utils.ZkUtilsWrapper
+import com.twitter.util.Time
+import kafka.api.{OffsetRequest, PartitionOffsetRequestInfo}
+import kafka.common.TopicAndPartition
+import kafka.utils.{Json}
+import org.I0Itec.zkclient.ZkClient
+import org.I0Itec.zkclient.exception.ZkNoNodeException
+import org.apache.zookeeper.data.Stat
+
+import scala.collection._
+import scala.util.control.NonFatal
+
+/**
+ * a version that manages offsets saved by Storm Kafka Spout
+ */
+class StormOffsetGetter(theZkClient: ZkClient, zkOffsetBase: String, zkUtils: ZkUtilsWrapper = new ZkUtilsWrapper) extends OffsetGetter {
+
+  override val zkClient = theZkClient
+
+  override def processPartition(group: String, topic: String, pid: Int): Option[OffsetInfo] = {
+    try {
+      val (stateJson, stat: Stat) = zkUtils.readData(zkClient, s"$zkOffsetBase/$group/partition_$pid")
+
+      val offset: String = Json.parseFull(stateJson) match {
+        case Some(m) =>
+          val spoutState = m.asInstanceOf[Map[String, Any]]
+          spoutState.getOrElse("offset", "-1").toString
+        case None =>
+          "-1"
+      }
+
+      zkUtils.getLeaderForPartition(zkClient, topic, pid) match {
+        case Some(bid) =>
+          val consumerOpt = consumerMap.getOrElseUpdate(bid, getConsumer(bid))
+          consumerOpt map {
+            consumer =>
+              val topicAndPartition = TopicAndPartition(topic, pid)
+              val request =
+                OffsetRequest(immutable.Map(topicAndPartition -> PartitionOffsetRequestInfo(OffsetRequest.LatestTime, 1)))
+              val logSize = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets.head
+
+              OffsetInfo(group = group,
+                topic = topic,
+                partition = pid,
+                offset = offset.toLong,
+                logSize = logSize,
+                owner = Some("NA"),
+                creation = Time.fromMilliseconds(stat.getCtime),
+                modified = Time.fromMilliseconds(stat.getMtime))
+          }
+        case None =>
+          error("No broker for partition %s - %s".format(topic, pid))
+          None
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"Could not parse partition info. group: [$group] topic: [$topic]", t)
+        None
+    }
+  }
+
+  override def getGroups: Seq[String] = {
+    try {
+      zkUtils.getChildren(zkClient, zkOffsetBase)
+    } catch {
+      case NonFatal(t) =>
+        error(s"could not get groups because of ${t.getMessage}", t)
+        Seq()
+    }
+  }
+
+  /**
+   * Finds all topics for this group, for Kafka Spout there is only one
+   */
+  override def getTopicList(group: String): List[String] = {
+    try {
+      // assume there should be partition 0
+      val (stateJson, _) = zkUtils.readData(zkClient, s"$zkOffsetBase/$group/partition_0")
+      println(stateJson)
+      Json.parseFull(stateJson) match {
+        case Some(m) =>
+          val spoutState = m.asInstanceOf[Map[String, Any]]
+          List(spoutState.getOrElse("topic", "Unknown Topic").toString)
+        case None =>
+          List()
+      }
+    } catch {
+      case _: ZkNoNodeException => List()
+    }
+  }
+
+  /**
+   * Returns a map of topics -> list of consumers, including non-active
+   */
+  override def getTopicMap: Map[String, Seq[String]] = {
+    try {
+      zkUtils.getChildren(zkClient, zkOffsetBase).flatMap {
+        group => {
+          getTopicList(group).map(topic => topic -> group)
+        }
+      }.groupBy(_._1).mapValues {
+        _.unzip._2
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"could not get topic maps because of ${t.getMessage}", t)
+        Map()
+    }
+  }
+
+  override def getActiveTopicMap: Map[String, Seq[String]] = {
+    // not really have a way to determine which consumer is active now, so return all
+    getTopicMap
+  }
+}

--- a/src/main/scala/com/quantifind/kafka/core/ZKOffsetGetter.scala
+++ b/src/main/scala/com/quantifind/kafka/core/ZKOffsetGetter.scala
@@ -1,0 +1,120 @@
+package com.quantifind.kafka.core
+
+import com.quantifind.kafka.OffsetGetter
+import OffsetGetter.OffsetInfo
+import com.quantifind.utils.ZkUtilsWrapper
+import com.twitter.util.Time
+import kafka.api.{OffsetRequest, PartitionOffsetRequestInfo}
+import kafka.common.TopicAndPartition
+import org.I0Itec.zkclient.ZkClient
+import org.I0Itec.zkclient.exception.ZkNoNodeException
+import org.apache.zookeeper.data.Stat
+
+import scala.collection._
+import scala.util.control.NonFatal
+
+/**
+ * a nicer version of kafka's ConsumerOffsetChecker tool
+ * User: pierre
+ * Date: 1/22/14
+ */
+class ZKOffsetGetter(theZkClient: ZkClient, zkUtils: ZkUtilsWrapper = new ZkUtilsWrapper) extends OffsetGetter {
+
+  override val zkClient = theZkClient
+
+  override def processPartition(group: String, topic: String, pid: Int): Option[OffsetInfo] = {
+    try {
+      val (offset, stat: Stat) = zkUtils.readData(zkClient, s"${zkUtils.ConsumersPath}/$group/offsets/$topic/$pid")
+      val (owner, _) = zkUtils.readDataMaybeNull(zkClient, s"${zkUtils.ConsumersPath}/$group/owners/$topic/$pid")
+
+      zkUtils.getLeaderForPartition(zkClient, topic, pid) match {
+        case Some(bid) =>
+          val consumerOpt = consumerMap.getOrElseUpdate(bid, getConsumer(bid))
+          consumerOpt map {
+            consumer =>
+              val topicAndPartition = TopicAndPartition(topic, pid)
+              val request =
+                OffsetRequest(immutable.Map(topicAndPartition -> PartitionOffsetRequestInfo(OffsetRequest.LatestTime, 1)))
+              val logSize = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets.head
+
+              OffsetInfo(group = group,
+                topic = topic,
+                partition = pid,
+                offset = offset.toLong,
+                logSize = logSize,
+                owner = owner,
+                creation = Time.fromMilliseconds(stat.getCtime),
+                modified = Time.fromMilliseconds(stat.getMtime))
+          }
+        case None =>
+          error("No broker for partition %s - %s".format(topic, pid))
+          None
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"Could not parse partition info. group: [$group] topic: [$topic]", t)
+        None
+    }
+  }
+
+  override def getGroups: Seq[String] = {
+    try {
+      zkUtils.getChildren(zkClient, zkUtils.ConsumersPath)
+    } catch {
+      case NonFatal(t) =>
+        error(s"could not get groups because of ${t.getMessage}", t)
+        Seq()
+    }
+  }
+
+  override def getTopicList(group: String): List[String] = {
+    try {
+      zkUtils.getChildren(zkClient, s"${zkUtils.ConsumersPath}/$group/offsets").toList
+    } catch {
+      case _: ZkNoNodeException => List()
+    }
+  }
+
+  /**
+   * Returns a map of topics -> list of consumers, including non-active
+   */
+  override def getTopicMap: Map[String, Seq[String]] = {
+    try {
+      zkUtils.getChildren(zkClient, zkUtils.ConsumersPath).flatMap {
+        group => {
+          getTopicList(group).map(topic => topic -> group)
+        }
+      }.groupBy(_._1).mapValues {
+        _.unzip._2
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"could not get topic maps because of ${t.getMessage}", t)
+        Map()
+    }
+  }
+
+  override def getActiveTopicMap: Map[String, Seq[String]] = {
+    try {
+      zkUtils.getChildren(zkClient, zkUtils.ConsumersPath).flatMap {
+        group =>
+          try {
+            zkUtils.getConsumersPerTopic(zkClient, group, true).keySet.map {
+              key =>
+                key -> group
+            }
+          } catch {
+            case NonFatal(t) =>
+              error(s"could not get consumers for group $group", t)
+              Seq()
+          }
+      }.groupBy(_._1).mapValues {
+        _.unzip._2
+      }
+    } catch {
+      case NonFatal(t) =>
+        error(s"could not get topic maps because of ${t.getMessage}", t)
+        Map()
+    }
+  }
+}

--- a/src/main/scala/com/quantifind/utils/ZkUtilsWrapper.scala
+++ b/src/main/scala/com/quantifind/utils/ZkUtilsWrapper.scala
@@ -1,0 +1,130 @@
+package com.quantifind.utils
+
+import kafka.api.LeaderAndIsr
+import kafka.cluster.{Cluster, Broker}
+import kafka.common.TopicAndPartition
+import kafka.consumer.ConsumerThreadId
+import kafka.controller.{ReassignedPartitionsContext, LeaderIsrAndControllerEpoch}
+import kafka.utils.ZkUtils
+import org.I0Itec.zkclient.ZkClient
+import org.apache.zookeeper.data.Stat
+
+import scala.collection.mutable
+
+/*
+  This class is mainly to help us mock the ZkUtils class. It is really painful to get powermock to work with scalatest,
+  so we created this class with a little help from IntelliJ to auto-generate the delegation code
+ */
+class ZkUtilsWrapper {
+
+  val ConsumersPath = ZkUtils.ConsumersPath
+
+  val delegator =  ZkUtils
+
+  def getAllPartitions(zkClient: ZkClient): collection.Set[TopicAndPartition] = delegator.getAllPartitions(zkClient)
+
+  def getAllTopics(zkClient: ZkClient): Seq[String] = delegator.getAllTopics(zkClient)
+
+  def getBrokerInfo(zkClient: ZkClient, brokerId: Int): Option[Broker] = delegator.getBrokerInfo(zkClient, brokerId)
+
+  def getConsumersPerTopic(zkClient: ZkClient, group: String, excludeInternalTopics: Boolean): mutable.Map[String, List[ConsumerThreadId]] = delegator.getConsumersPerTopic(zkClient, group, excludeInternalTopics)
+
+  def getConsumersInGroup(zkClient: ZkClient, group: String): Seq[String] = delegator.getConsumersInGroup(zkClient, group)
+
+  def deletePartition(zkClient: ZkClient, brokerId: Int, topic: String): Unit = delegator.deletePartition(zkClient, brokerId, topic)
+
+  def getPartitionsUndergoingPreferredReplicaElection(zkClient: ZkClient): collection.Set[TopicAndPartition] = delegator.getPartitionsUndergoingPreferredReplicaElection(zkClient)
+
+  def updatePartitionReassignmentData(zkClient: ZkClient, partitionsToBeReassigned: collection.Map[TopicAndPartition, Seq[Int]]): Unit = delegator.updatePartitionReassignmentData(zkClient, partitionsToBeReassigned)
+
+  def getPartitionReassignmentZkData(partitionsToBeReassigned: collection.Map[TopicAndPartition, Seq[Int]]): String = delegator.getPartitionReassignmentZkData(partitionsToBeReassigned)
+
+  def parseTopicsData(jsonData: String): Seq[String] = delegator.parseTopicsData(jsonData)
+
+  def parsePartitionReassignmentData(jsonData: String): collection.Map[TopicAndPartition, Seq[Int]] = delegator.parsePartitionReassignmentData(jsonData)
+
+  def parsePartitionReassignmentDataWithoutDedup(jsonData: String): Seq[(TopicAndPartition, Seq[Int])] = delegator.parsePartitionReassignmentDataWithoutDedup(jsonData)
+
+  def getPartitionsBeingReassigned(zkClient: ZkClient): collection.Map[TopicAndPartition, ReassignedPartitionsContext] = delegator.getPartitionsBeingReassigned(zkClient)
+
+  def getPartitionsForTopics(zkClient: ZkClient, topics: Seq[String]): mutable.Map[String, Seq[Int]] = delegator.getPartitionsForTopics(zkClient, topics)
+
+  def getPartitionAssignmentForTopics(zkClient: ZkClient, topics: Seq[String]): mutable.Map[String, collection.Map[Int, Seq[Int]]] = delegator.getPartitionAssignmentForTopics(zkClient, topics)
+
+  def getReplicaAssignmentForTopics(zkClient: ZkClient, topics: Seq[String]): mutable.Map[TopicAndPartition, Seq[Int]] = delegator.getReplicaAssignmentForTopics(zkClient, topics)
+
+  def getPartitionLeaderAndIsrForTopics(zkClient: ZkClient, topicAndPartitions: collection.Set[TopicAndPartition]): mutable.Map[TopicAndPartition, LeaderIsrAndControllerEpoch] = delegator.getPartitionLeaderAndIsrForTopics(zkClient, topicAndPartitions)
+
+  def pathExists(client: ZkClient, path: String): Boolean = delegator.pathExists(client, path)
+
+  def getChildrenParentMayNotExist(client: ZkClient, path: String): Seq[String] = delegator.getChildrenParentMayNotExist(client, path)
+
+  def getChildren(client: ZkClient, path: String): Seq[String] = delegator.getChildren(client, path)
+
+  def readDataMaybeNull(client: ZkClient, path: String): (Option[String], Stat) = delegator.readDataMaybeNull(client, path)
+
+  def readData(client: ZkClient, path: String): (String, Stat) = delegator.readData(client, path)
+
+  def maybeDeletePath(zkUrl: String, dir: String): Unit = delegator.maybeDeletePath(zkUrl, dir)
+
+  def deletePathRecursive(client: ZkClient, path: String): Unit = delegator.deletePathRecursive(client, path)
+
+  def deletePath(client: ZkClient, path: String): Boolean = delegator.deletePath(client, path)
+
+  def updateEphemeralPath(client: ZkClient, path: String, data: String): Unit = delegator.updateEphemeralPath(client, path, data)
+
+  def conditionalUpdatePersistentPathIfExists(client: ZkClient, path: String, data: String, expectVersion: Int): (Boolean, Int) = delegator.conditionalUpdatePersistentPathIfExists(client, path, data, expectVersion)
+
+  def conditionalUpdatePersistentPath(client: ZkClient, path: String, data: String, expectVersion: Int, optionalChecker: Option[(ZkClient, String, String) => (Boolean, Int)]): (Boolean, Int) = delegator.conditionalUpdatePersistentPath(client, path, data, expectVersion, optionalChecker)
+
+  def updatePersistentPath(client: ZkClient, path: String, data: String): Unit = delegator.updatePersistentPath(client, path, data)
+
+  def createSequentialPersistentPath(client: ZkClient, path: String, data: String): String = delegator.createSequentialPersistentPath(client, path, data)
+
+  def createPersistentPath(client: ZkClient, path: String, data: String): Unit = delegator.createPersistentPath(client, path, data)
+
+  def createEphemeralPathExpectConflictHandleZKBug(zkClient: ZkClient, path: String, data: String, expectedCallerData: Any, checker: (String, Any) => Boolean, backoffTime: Int): Unit = delegator.createEphemeralPathExpectConflictHandleZKBug(zkClient, path, data, expectedCallerData, checker, backoffTime)
+
+  def createEphemeralPathExpectConflict(client: ZkClient, path: String, data: String): Unit = delegator.createEphemeralPathExpectConflict(client, path, data)
+
+  def makeSurePersistentPathExists(client: ZkClient, path: String): Unit = delegator.makeSurePersistentPathExists(client, path)
+
+  def replicaAssignmentZkData(map: collection.Map[String, Seq[Int]]): String = delegator.replicaAssignmentZkData(map)
+
+  def leaderAndIsrZkData(leaderAndIsr: LeaderAndIsr, controllerEpoch: Int): String = delegator.leaderAndIsrZkData(leaderAndIsr, controllerEpoch)
+
+  def getConsumerPartitionOwnerPath(group: String, topic: String, partition: Int): String = delegator.getConsumerPartitionOwnerPath(group, topic, partition)
+
+  def registerBrokerInZk(zkClient: ZkClient, id: Int, host: String, port: Int, timeout: Int, jmxPort: Int): Unit = delegator.registerBrokerInZk(zkClient, id, host, port, timeout, jmxPort)
+
+  def getReplicasForPartition(zkClient: ZkClient, topic: String, partition: Int): Seq[Int] = delegator.getReplicasForPartition(zkClient, topic, partition)
+
+  def getInSyncReplicasForPartition(zkClient: ZkClient, topic: String, partition: Int): Seq[Int] = delegator.getInSyncReplicasForPartition(zkClient, topic, partition)
+
+  def getEpochForPartition(zkClient: ZkClient, topic: String, partition: Int): Int = delegator.getEpochForPartition(zkClient, topic, partition)
+
+  def getLeaderForPartition(zkClient: ZkClient, topic: String, partition: Int): Option[Int] = delegator.getLeaderForPartition(zkClient, topic, partition)
+
+  def setupCommonPaths(zkClient: ZkClient): Unit = delegator.setupCommonPaths(zkClient)
+
+  def getLeaderAndIsrForPartition(zkClient: ZkClient, topic: String, partition: Int): Option[LeaderAndIsr] = delegator.getLeaderAndIsrForPartition(zkClient, topic, partition)
+
+  def getAllBrokersInCluster(zkClient: ZkClient): Seq[Broker] = delegator.getAllBrokersInCluster(zkClient)
+
+  def getSortedBrokerList(zkClient: ZkClient): Seq[Int] = delegator.getSortedBrokerList(zkClient)
+
+  def getTopicPartitionLeaderAndIsrPath(topic: String, partitionId: Int): String = delegator.getTopicPartitionLeaderAndIsrPath(topic, partitionId)
+
+  def getTopicPartitionPath(topic: String, partitionId: Int): String = delegator.getTopicPartitionPath(topic, partitionId)
+
+  def getController(zkClient: ZkClient): Int = delegator.getController(zkClient)
+
+  def getDeleteTopicPath(topic: String): String = delegator.getDeleteTopicPath(topic)
+
+  def getTopicConfigPath(topic: String): String = delegator.getTopicConfigPath(topic)
+
+  def getTopicPartitionsPath(topic: String): String = delegator.getTopicPartitionsPath(topic)
+
+  def getTopicPath(topic: String): String = delegator.getTopicPath(topic)
+
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.reflections.Reflections=ERROR

--- a/src/test/scala/com/quantifind/kafka/core/KafkaOffsetGetterSpec.scala
+++ b/src/test/scala/com/quantifind/kafka/core/KafkaOffsetGetterSpec.scala
@@ -1,0 +1,56 @@
+package com.quantifind.kafka.core
+
+import com.quantifind.kafka.core.KafkaOffsetGetter.GroupTopicPartition
+import com.quantifind.utils.ZkUtilsWrapper
+import kafka.api.{OffsetRequest, OffsetResponse, PartitionOffsetsResponse}
+import kafka.common.{OffsetAndMetadata, TopicAndPartition}
+import kafka.consumer.SimpleConsumer
+import org.I0Itec.zkclient.ZkClient
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.mockito.{Matchers => MockitoMatchers, Mockito}
+import org.scalatest._
+
+class KafkaOffsetGetterSpec extends FlatSpec with ShouldMatchers {
+
+  trait Fixture {
+
+    val mockedZkClient = Mockito.mock(classOf[ZkClient])
+    val mockedZkUtil =  Mockito.mock(classOf[ZkUtilsWrapper])
+    val mockedConsumer = Mockito.mock(classOf[SimpleConsumer])
+    val testPartitionLeader = 1
+
+    val offsetGetter = new KafkaOffsetGetter(mockedZkClient, mockedZkUtil)
+    offsetGetter.consumerMap += (testPartitionLeader -> Some(mockedConsumer))
+  }
+
+  "KafkaOffsetGetter" should "be able to build offset data for given partition" in new Fixture {
+
+    val testGroup = "testgroup"
+    val testTopic = "testtopic"
+    val testPartition = 1
+
+    val topicAndPartition = TopicAndPartition(testTopic, testPartition)
+    val groupTopicPartition = GroupTopicPartition(testGroup, topicAndPartition)
+    val offsetAndMetadata = OffsetAndMetadata(100, "meta", System.currentTimeMillis)
+    KafkaOffsetGetter.offsetMap += (groupTopicPartition -> offsetAndMetadata)
+
+    when(mockedZkUtil.getLeaderForPartition(MockitoMatchers.eq(mockedZkClient), MockitoMatchers.eq(testTopic), MockitoMatchers.eq(testPartition)))
+      .thenReturn(Some(testPartitionLeader))
+
+    val partitionErrorAndOffsets = Map(topicAndPartition -> PartitionOffsetsResponse(0,Seq(102)))
+    val offsetResponse = OffsetResponse(1, partitionErrorAndOffsets)
+    when(mockedConsumer.getOffsetsBefore(any[OffsetRequest])).thenReturn(offsetResponse)
+
+    offsetGetter.processPartition(testGroup, testTopic, testPartition) match {
+      case Some(offsetInfo) =>
+        offsetInfo.topic shouldBe testTopic
+        offsetInfo.group shouldBe testGroup
+        offsetInfo.partition shouldBe testPartition
+        offsetInfo.offset shouldBe 100
+        offsetInfo.logSize shouldBe 102
+      case None => fail("Failed to build offset data")
+    }
+    
+  }
+}

--- a/src/test/scala/com/quantifind/kafka/core/StormOffsetGetterSpec.scala
+++ b/src/test/scala/com/quantifind/kafka/core/StormOffsetGetterSpec.scala
@@ -1,0 +1,47 @@
+package com.quantifind.kafka.core
+
+import com.quantifind.utils.ZkUtilsWrapper
+import org.I0Itec.zkclient.ZkClient
+import org.apache.zookeeper.data.Stat
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.mockito.{Matchers => MockitoMatchers, Mockito}
+import org.scalatest._
+
+class StormOffsetGetterSpec extends FlatSpec with ShouldMatchers {
+
+  trait Fixture {
+
+    val mockedZkClient = Mockito.mock(classOf[ZkClient])
+    val zkOffsetBase = "/stormconsumers"
+    val mockedZkUtil =  Mockito.mock(classOf[ZkUtilsWrapper])
+
+    val offsetGetter = new StormOffsetGetter(mockedZkClient, zkOffsetBase, mockedZkUtil)
+  }
+
+  "StormOffsetGetter" should "be able to extract topic from persisted spout state" in new Fixture {
+
+    val testGroup = "testgroup"
+    val testTopic = "testtopic"
+    val spoutState = s"""{
+                        "broker": {
+                            "host": "kafka.sample.net",
+                            "port": 9092
+                        },
+                        "offset": 4285,
+                        "partition": 1,
+                        "topic": "${testTopic}",
+                        "topology": {
+                            "id": "fce905ff-25e0 -409e-bc3a-d855f 787d13b",
+                            "name": "Test Topology"
+                        }
+                       }"""
+    val ret = (spoutState, Mockito.mock(classOf[Stat]))
+    when(mockedZkUtil.readData(MockitoMatchers.eq(mockedZkClient), anyString)).thenReturn(ret)
+
+    val topics = offsetGetter.getTopicList(testGroup)
+    
+    topics.size shouldBe 1
+    topics(0) shouldBe testTopic
+  }
+}

--- a/src/test/scala/com/quantifind/kafka/core/ZKOffsetGetterSpec.scala
+++ b/src/test/scala/com/quantifind/kafka/core/ZKOffsetGetterSpec.scala
@@ -1,0 +1,48 @@
+package com.quantifind.kafka.core
+
+import com.quantifind.utils.ZkUtilsWrapper
+import org.I0Itec.zkclient.ZkClient
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.mockito.{Matchers => MockitoMatchers, Mockito}
+import org.scalatest._
+
+class ZKOffsetGetterSpec extends FlatSpec with ShouldMatchers {
+
+  trait Fixture {
+
+    val mockedZkClient = Mockito.mock(classOf[ZkClient])
+    val mockedZkUtil =  Mockito.mock(classOf[ZkUtilsWrapper])
+
+    val offsetGetter = new ZKOffsetGetter(mockedZkClient, mockedZkUtil)
+  }
+
+  "ZKOffsetGetter" should "be able to fetch topic list" in new Fixture {
+
+    val testGroup = "testgroup"
+    val testTopic1 = "testtopic1"
+    val testTopic2 = "testtopic2"
+
+    when(mockedZkUtil.getChildren(MockitoMatchers.eq(mockedZkClient), anyString)).thenReturn(Seq(testTopic1, testTopic2))
+
+    val topics = offsetGetter.getTopicList(testGroup)
+    
+    topics.size shouldBe 2
+    topics(0) shouldBe testTopic1
+    topics(1) shouldBe testTopic2
+  }
+
+  "ZKOffsetGetter" should "be able to fetch consumer group list" in new Fixture {
+
+    val testGroup1 = "testgroup1"
+    val testGroup2 = "testgroup2"
+
+    when(mockedZkUtil.getChildren(MockitoMatchers.eq(mockedZkClient), anyString)).thenReturn(Seq(testGroup1, testGroup2))
+
+    val groups = offsetGetter.getGroups
+
+    groups.size shouldBe 2
+    groups(0) shouldBe testGroup1
+    groups(1) shouldBe testGroup2
+  }
+}


### PR DESCRIPTION
Hi,

We have been using this tool in production for a while and really like it.  Recently we have migrated many of applications to use Kafka internal topic instead of ZK for offset management, we also started new development of applications running on Apache Storm to consume Kafka messages.  To be able to leverage KafkaOffsetMonitor to monitor all those different type of systems,  we have enhanced the current KafkaOffsetMonitor implementation to support those two new types of offset formats.   Details can be found in the updated README.md.  As more and more Kafka applications will be migrating to use the Kafka internal topic as offset storage,  I hope these new features can benefit other users of this great tool.

Regards,

Hang
 