### PR TITLE
Add pager duty alerts

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,6 +8,7 @@ object KafkaUtilsBuild extends Build {
   def sharedSettings = Defaults.defaultSettings ++ assemblySettings ++ Seq(
     version := "0.3.0-SNAPSHOT",
     scalaVersion := "2.10.3",
+    mainClass in (Compile, packageBin) := Some("com.quantifind.kafka.offsetapp.OffsetGetterWeb"),
     organization := "com.quantifind",
     scalacOptions := Seq("-deprecation", "-unchecked", "-optimize"),
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
@@ -22,7 +23,8 @@ object KafkaUtilsBuild extends Build {
       "log4j" % "log4j" % "1.2.17",
       "org.scalatest" %% "scalatest" % "2.2.4" % "test",
       "org.mockito" % "mockito-all" % "1.10.19" % "test",
-      "org.apache.kafka" %% "kafka" % "0.8.2.1"))
+      "org.apache.kafka" %% "kafka" % "0.8.2.1",
+      "com.squareup.pagerduty" % "pagerduty-incidents" % "1.0.1"))
 
   val slf4jVersion = "1.6.1"
 

--- a/src/main/scala/com/quantifind/kafka/offsetapp/alerts/PagerDutyOffsetInfoReporter.scala
+++ b/src/main/scala/com/quantifind/kafka/offsetapp/alerts/PagerDutyOffsetInfoReporter.scala
@@ -1,0 +1,43 @@
+package com.quantifind.kafka.offsetapp.alerts
+
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+import com.quantifind.kafka.offsetapp.{OWArgs, OffsetInfoReporter}
+import com.squareup.pagerduty.incidents.{PagerDuty, Trigger}
+import kafka.utils.Logging
+
+/**
+  * Created by radu on 02/02/16.
+  */
+class PagerDutyOffsetInfoReporter(args: OWArgs) extends OffsetInfoReporter with Logging {
+
+    private val pagerDuty = PagerDuty.create(args.pagerDutyKey)
+
+    private val groupTopicMaxLagMap: Map[String, Long] = createGroupTopicMaxLagMap(args.groupTopicMaxLagConfigs)
+
+    override def report(offsetInfoSeq: IndexedSeq[OffsetInfo]) = {
+        offsetInfoSeq.foreach { offsetInfo =>
+            groupTopicMaxLagMap.get(s"${offsetInfo.group}:${offsetInfo.topic}").foreach { maxLag =>
+                if (offsetInfo.lag > maxLag) {
+                    info(s"Max lag of ${maxLag} exceeded for Group = ${offsetInfo.group}, Topic = ${offsetInfo.topic}, Lag = ${offsetInfo.lag}")
+                    triggerLagAlert(offsetInfo.group, offsetInfo.topic, offsetInfo.lag)
+                }
+            }
+        }
+    }
+
+    private def triggerLagAlert(consumerGroup: String, topic: String, lag: Long) = {
+        val trigger = new Trigger.Builder(s"${consumerGroup} - ${topic} lag is $lag")
+            .withIncidentKey(s"$consumerGroup-$topic")
+            .addDetails("Consumer Group", consumerGroup)
+            .addDetails("Topic", topic)
+            .addDetails("Lag", lag.toString)
+            .build
+        pagerDuty.notify(trigger)
+    }
+
+    private def createGroupTopicMaxLagMap(configs: String): Map[String, Long] = {
+        Map[String, Long]() ++ configs.split(",")
+            .map { entry => entry.split("=") }
+            .map { array => (array(0), array(1).toLong) }
+    }
+}


### PR DESCRIPTION
For this to work you need 2 more arguments:
--pagerDutyKey YOUR_KEY 
--groupTopicMaxLagConfigs group1:topic1=100,group1:topic2=1000

For simplicity, the alerts are not stored in the database, so an alert can be triggered multiple times if the issue is not solved quickly.